### PR TITLE
Fix hero flash on index page

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -3,40 +3,15 @@ import styled from 'styled-components'
 import Navigation from './Navigation'
 
 class MainHeader extends React.Component {
-  getHeader() {
-    if (this.props.location) {
-      if (this.props.location.pathname === '/') {
-        return (
-          <IndexHeadContainer>
-            <Navigation />
-            <Hero>
-              <img src={this.props.logo} width='150px' />
-              <h1>{this.props.siteTitle}</h1>
-              <h4>{this.props.siteDescription}</h4>
-            </Hero>
-          </IndexHeadContainer>
-        )
-      } else {
-        return (
-          <SiteContainer>
-            <Navigation />
-          </SiteContainer>
-        )
-      }
-    }
-    return <div></div>
-  }
 
   render() {
-    return this.getHeader()
+    return (
+      <SiteContainer>
+        <Navigation />
+      </SiteContainer>
+    )
   }
 }
-
-const IndexHeadContainer = styled.div`
-  background: ${props => props.theme.brand};
-  padding: ${props => props.theme.sitePadding};
-  text-align: center;
-`
 
 const SiteContainer = styled.div`
   display: flex;
@@ -47,13 +22,4 @@ const SiteContainer = styled.div`
   padding:  25px;
 `
 
-const Hero = styled.div`
-  padding: 50px 0;
-  & > h1 {
-    font-weight: 600;  
-  }
-`
-
 export default MainHeader
-
-

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,8 +4,8 @@ import styled from "styled-components"
 
 import SEO from "../components/SEO/SEO"
 import config from "../../data/SiteConfig"
-import MainHeader from '../components/Layout/Header'
 import CtaButton from '../components/CtaButton'
+import Navigation from '../components/Layout/Navigation'
 
 class Index extends React.Component {
 
@@ -16,12 +16,14 @@ class Index extends React.Component {
         <Helmet title={config.siteTitle} />
         <SEO postEdges={postEdges} />
         <main>
-          <MainHeader
-            siteTitle={config.siteTitle}
-            siteDescription={config.siteDescription}
-            location={this.props.location}
-            logo={config.siteLogo}
-          />
+          <IndexHeadContainer>
+            <Navigation />
+            <Hero>
+              <img src={config.siteLogo} width='150px' />
+              <h1>{config.siteTitle}</h1>
+              <h4>{config.siteDescription}</h4>
+            </Hero>
+          </IndexHeadContainer>
           <BodyContainer>
             <h2>A Gatsby Template for Content</h2>
             <p>Made for modern documentation sites. Table of Contents automatically generated from markdown files. </p>
@@ -34,6 +36,19 @@ class Index extends React.Component {
 }
 
 export default Index;
+
+const IndexHeadContainer = styled.div`
+  background: ${props => props.theme.brand};
+  padding: ${props => props.theme.sitePadding};
+  text-align: center;
+`
+
+const Hero = styled.div`
+  padding: 50px 0;
+  & > h1 {
+    font-weight: 600;
+  }
+`
 
 const BodyContainer = styled.div`
   padding: ${props => props.theme.sitePadding};


### PR DESCRIPTION
On the main index page, there's a flash on reload before the Hero is displayed. Looks like this is happening because it's based on the path of the page and thus can't be prerendered.

I switched the conditional logic out so the Index page is rendered with the Hero and the other pages that use the Navigation just get the Nav.

Example below showing the original behavior and then the new behavior:

![gatsbydocs](https://user-images.githubusercontent.com/6509926/34471401-530656aa-ef0e-11e7-9dc0-b866c103b815.gif)

Open to suggestions on changes. Thanks for the template!