### PR TITLE
Fix jumping header

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -18,7 +18,6 @@ const SiteContainer = styled.div`
   align-items: center;
   justify-content: space-between;
   background: ${props => props.theme.brand};
-  height: 100%;
   padding:  25px;
 `
 


### PR DESCRIPTION
Stop the header from jumping when navigating in the main site menu.
Fix #10.